### PR TITLE
Add a new ExtractPropertiesWithCount method.

### DIFF
--- a/Vostok.Commons.Formatting.Tests/ObjectPropertiesExtractor_Tests.cs
+++ b/Vostok.Commons.Formatting.Tests/ObjectPropertiesExtractor_Tests.cs
@@ -13,57 +13,103 @@ namespace Vostok.Commons.Formatting.Tests
         [Test]
         public void Should_extract_properties_from_an_anonymous_object()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new {A = 1, B = 2})
+            var obj = new {A = 1, B = 2};
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEquivalentTo(("A", 1), ("B", 2));
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(2);
+            props.Should()
+                .BeEquivalentTo(ObjectPropertiesExtractor.ExtractProperties(obj));
         }
 
         [Test]
         public void Should_extract_properties_from_a_custom_object()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new Container())
+            var obj = new Container();
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEquivalentTo(("A", 1), ("B", 2));
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(2);
+            props.Should()
+                .BeEquivalentTo(ObjectPropertiesExtractor.ExtractProperties(obj));
         }
 
         [Test]
         public void Should_not_extract_private_properties()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new PrivateProperty())
+            var obj = new PrivateProperty();
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEmpty();
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(0);
+            props.Should().BeEmpty();
         }
 
         [Test]
         public void Should_not_extract_public_fields()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new PublicField())
+            var obj = new PublicField();
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEmpty();
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(0);
+            props.Should().BeEmpty();
         }
 
         [Test]
         public void Should_not_extract_private_fields()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new PrivateField())
+            var obj = new PrivateField();
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEmpty();
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(0);
+            props.Should().BeEmpty();
         }
 
         [Test]
         public void Should_return_error_messages_as_values_for_failing_properties()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new ThrowingProperty())
+            var obj = new ThrowingProperty();
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .Equal(("A", "<error: 123>"));
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(1);
+            props.Should()
+                .BeEquivalentTo(ObjectPropertiesExtractor.ExtractProperties(obj));
         }
 
         [Test]
         public void Should_support_properties_that_differ_by_case_only()
         {
-            ObjectPropertiesExtractor.ExtractProperties(new {A = 1, a = 2})
+            var obj = new {A = 1, a = 2};
+
+            ObjectPropertiesExtractor.ExtractProperties(obj)
                 .Should()
                 .BeEquivalentTo(("A", 1), ("a", 2));
+
+            var (count, props) = ObjectPropertiesExtractor.ExtractPropertiesWithCount(obj);
+            count.Should().Be(2);
+            props.Should()
+                .BeEquivalentTo(ObjectPropertiesExtractor.ExtractProperties(obj));
         }
 
         private class Container

--- a/Vostok.Commons.Formatting/ObjectPropertiesExtractor.cs
+++ b/Vostok.Commons.Formatting/ObjectPropertiesExtractor.cs
@@ -30,6 +30,18 @@ namespace Vostok.Commons.Formatting
                 yield return (name, ObtainPropertyValue(@object, getter));
         }
 
+        public static (int, IEnumerable<(string, object)>) ExtractPropertiesWithCount(object @object)
+        {
+            var pairs = Cache.Obtain(@object.GetType(), obj => LocateProperties(obj));
+            return (pairs.Length, Get(@object, pairs));
+        }
+
+        private static IEnumerable<(string, object)> Get(object @object, (string name, Func<object, object> getter)[] pairs)
+        {
+            foreach (var (name, getter) in pairs)
+                yield return (name, ObtainPropertyValue(@object, getter));
+        }
+
         private static (string, Func<object, object>)[] LocateProperties(Type type)
         {
             try


### PR DESCRIPTION
Add a new ExtractPropertiesWithCount method to know exactly the length of the resulting collection. It is important in case consumers want to allocate the resulting container once.